### PR TITLE
Improved leak diff reporting and matcher methods

### DIFF
--- a/lib/rspec/files/leaks.rb
+++ b/lib/rspec/files/leaks.rb
@@ -42,7 +42,7 @@ module RSpec
 				before_ios
 				
 				example.run.tap do
-					expect(after_ios).to be == before_ios
+					expect(after_ios - before_ios).to eq([ ])
 				end
 			end
 		end

--- a/spec/rspec/files/leaks_spec.rb
+++ b/spec/rspec/files/leaks_spec.rb
@@ -50,4 +50,24 @@ RSpec.describe "leaks context" do
 
 		expect(created_ios { input, output = IO.pipe; input.close; output.close }.length).to eq(0)
 	end
+
+	describe "can expect" do
+		it "to leak_handles" do
+			retain_leaks do |leaks|
+				expect { leaks << File.open(__FILE__) }.to leak_handles
+				expect { leaks << File.open(__FILE__) }.to leak_handles(1)
+				expect { leaks << File.open(__FILE__) }.to_not leak_handles(2)
+			end
+		end
+
+		it "to not_leak_handles" do
+			retain_leaks do |leaks|
+				expect { File.open(__FILE__).close }.to not_leak_handles
+
+				expect {
+					expect { leaks << File.open(__FILE__) }.to not_leak_handles
+				}.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+			end
+		end
+	end
 end


### PR DESCRIPTION
<!--
  What changes are being made? What problem are you solving?
  What feature/bug is being fixed here?
  If this is an aesthetic change, please include screenshots.
-->

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [x] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [x] I added new tests for my changes.
- [x] I ran all the tests locally.

The current method for reporting IO leaks is to just dump out all the handles that were present before the test, and then all those present after the test. Due to the way RSpec produces diffs a lot of the details can get lost in truncation if this list has a lot of handles open before the test kicks off, frustrating efforts to pin down where the source of the leak is.

This changes the way IO handle leak detection is done by:

- Reporting only on anomalous IO handles that have shown up inside of the test, where handles that were present before do not need to be reported on and are omitted from the output.
- Refactoring the current leak detection `around(:each)` code to be a minimal wrapper around the new `created_ios` helper method.
- Exposes `created_ios` to user code to detect newly created IO handles and to facilitate testing this without having to test the RSpec test `around` hook specifically.
- Adds `leak_handles` and `not_leak_handles` matchers so you can `expect { ... }.to leak_handles`
- Makes `RSpec::Files::Leaks` call `extend self` so that these helper methods can be called directly without forcing an `include` into a context where that might not be appropriate.

I tried to make an RSpec test tester, but this is proving to be very tricky. By minimizing how much code is actually inside the `around` block it's less likely this will malfunction, but it would be nice to establish a specific test to ensure that's in place. Unfortunately any attempts I made to define an independent RSpec test tree that does not get executed in the course of testing proved fruitless.
