### PR TITLE
Require rspec/core before using RSpec methods

### DIFF
--- a/lib/rspec/files.rb
+++ b/lib/rspec/files.rb
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require 'rspec/core'
+
 require_relative "files/version"
 require_relative "files/leaks"
 require_relative "files/buffer"


### PR DESCRIPTION
As decided in https://github.com/socketry/async-rspec/pull/18, I move the change to this gem

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
-->

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
